### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.1.1+1] - May, 31, 2022
+
+* Automated dependency updates
+
+
 ## [2.1.0+2] - February 6th, 2022
 
 * Dependency updates
@@ -71,3 +76,4 @@
 ## [1.0.0] - May 31st, 2020
 
 * Initial release
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,26 +1,24 @@
-name: static_translations
-description: A translations package that always has reliable defaults and code safe keys.
-homepage: https://github.com/peiffer-innovations/static_translations
+name: 'static_translations'
+description: 'A translations package that always has reliable defaults and code safe keys.'
+homepage: 'https://github.com/peiffer-innovations/static_translations'
+version: '2.1.1+1'
 
-version: 2.1.1
-
-environment:
+environment: 
   sdk: '>=2.17.0 <3.0.0'
 
-dependencies:
-  flutter:
-    sdk: flutter
-  meta: ^1.7.0
-  provider: ^6.0.2
-  rest_client: ^2.1.3
+dependencies: 
+  flutter: 
+    sdk: 'flutter'
+  meta: '^1.7.0'
+  provider: '^6.0.3'
+  rest_client: '^2.1.4'
 
-dev_dependencies:
-  flutter_test:
-    sdk: flutter
+dev_dependencies: 
+  flutter_test: 
+    sdk: 'flutter'
 
-ignore_updates:
-  # Ignoring everything in flutter_test as those are all point-in-time entries
-  # can't upgrade without upgrading Flutter itself.
+
+ignore_updates: 
   - 'async'
   - 'boolean_selector'
   - 'characters'
@@ -39,5 +37,4 @@ ignore_updates:
   - 'string_scanner'
   - 'term_glyph'
   - 'vector_math'
-
-flutter:
+flutter: null


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `provider`: 6.0.2 --> 6.0.3
  * `rest_client`: 2.1.3 --> 2.1.4


Analysis Successful


