### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.1.1+8] - July 26, 2022
+
+* Automated dependency updates
+
+
 ## [2.1.1+7] - July 19, 2022
 
 * Automated dependency updates
@@ -106,6 +111,7 @@
 ## [1.0.0] - May 31st, 2020
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'static_translations'
 description: 'A translations package that always has reliable defaults and code safe keys.'
 homepage: 'https://github.com/peiffer-innovations/static_translations'
-version: '2.1.1+7'
+version: '2.1.1+8'
 
 environment: 
   sdk: '>=2.17.0 <3.0.0'
@@ -11,7 +11,7 @@ dependencies:
     sdk: 'flutter'
   meta: '^1.7.0'
   provider: '^6.0.3'
-  rest_client: '^2.1.4+6'
+  rest_client: '^2.1.4+7'
 
 dev_dependencies: 
   flutter_test: 


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `rest_client`: 2.1.4+6 --> 2.1.4+7


Analysis Successful


