### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.1.1+19] - December 20, 2022
+
+* Automated dependency updates
+
+
 ## [2.1.1+18] - November 22, 2022
 
 * Automated dependency updates
@@ -161,6 +166,7 @@
 ## [1.0.0] - May 31st, 2020
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'static_translations'
 description: 'A translations package that always has reliable defaults and code safe keys.'
 homepage: 'https://github.com/peiffer-innovations/static_translations'
-version: '2.1.1+18'
+version: '2.1.1+19'
 
 environment: 
   sdk: '>=2.18.0 <3.0.0'
@@ -10,8 +10,8 @@ dependencies:
   flutter: 
     sdk: 'flutter'
   meta: '^1.7.0'
-  provider: '^6.0.4'
-  rest_client: '^2.2.0+3'
+  provider: '^6.0.5'
+  rest_client: '^2.2.0+4'
 
 dev_dependencies: 
   flutter_test: 


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `provider`: 6.0.4 --> 6.0.5
  * `rest_client`: 2.2.0+3 --> 2.2.0+4


Analysis Successful


